### PR TITLE
fix: install sim config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -48,6 +48,10 @@ install(TARGETS
   DESTINATION lib/${PROJECT_NAME}
 )
 
+install(DIRECTORY config
+  DESTINATION share/${PROJECT_NAME}
+)
+
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights


### PR DESCRIPTION
## Problem

`ap1_pnc_sim` ships default world YAML files under `config/`, but the package does not install that directory. Launch files cannot reliably resolve a default world through `get_package_share_directory('ap1_pnc_sim')` after `colcon build`/install.

## Changes

- Install the `config/` directory into `share/${PROJECT_NAME}`.

## Test plan

- [ ] `colcon build --packages-select ap1_pnc_sim`
- [ ] `source install/setup.bash`
- [ ] Confirm `install/ap1_pnc_sim/share/ap1_pnc_sim/config/generated_circle.yaml` exists
- [ ] Run `ros2 run ap1_pnc_sim sim $(ros2 pkg prefix ap1_pnc_sim)/share/ap1_pnc_sim/config/generated_circle.yaml`
